### PR TITLE
Add support for and start testing against Ruby 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - checkout
       - restore_cache:
           key: gemfile-<< parameters.ruby_version >>-{{ checksum "Gemfile" }}
-      - run: gem install bundler:2.6.7
+      - run: gem install bundler:4.0.7 --no-document
       - run: bundle install -j3
       - save_cache:
           key: gemfile-<< parameters.ruby_version >>-{{ checksum "Gemfile" }}
@@ -33,7 +33,7 @@ jobs:
       - checkout
       - restore_cache:
           key: gemfile-<< parameters.ruby_version >>-{{ checksum "Gemfile" }}
-      - run: gem install bundler:2.6.7
+      - run: gem install bundler:4.0.7 --no-document
       - run: bundle install -j3
       - run: bundle check
       - run: bundle exec rubocop
@@ -54,11 +54,11 @@ workflows:
           context: org-global
           matrix:
             parameters:
-              ruby_version: ['3.2', '3.3', '3.4']
+              ruby_version: ['3.2', '3.3', '3.4', '4.0']
       - ruby:
           context: org-global
           matrix:
             parameters:
-              ruby_version: ['3.2', '3.3', '3.4']
+              ruby_version: ['3.2', '3.3', '3.4', '4.0']
           requires:
             - bundle

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
 end
 
 group :test do
+  gem 'ostruct'
   gem 'rspec', '~> 3.0'
   gem 'rspec_junit_formatter', '~> 0.3'
   gem 'timecop'


### PR DESCRIPTION
### Description

Proposing we add support for and start testing against Ruby 4 as it's the latest version and has been out for about two months now. Additionally proposing we use latest bundler in CI.

- https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
- https://www.ruby-lang.org/en/news/2026/01/13/ruby-4-0-1-released/
- https://github.com/ruby/rubygems/releases/tag/bundler-v4.0.7

The addition of `ostruct` to the Gemfile is because as of Ruby 4 it's no longer include by default. (log below)

```console
❯ bundle exec rspec
/home/larouxn/src/github.com/larouxn/selligent-rb/spec/selligent/client/cumulio_spec.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.0.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.

Randomized with seed 25022
.....................................................................

Finished in 0.02478 seconds (files took 0.17444 seconds to load)
69 examples, 0 failures

Randomized with seed 25022
```

### Testing

<img width="2880" height="1856" alt="image" src="https://github.com/user-attachments/assets/d32329bf-8c0c-4449-bbc4-0cb67b897390" />