### PR TITLE
PT-8689: switch CircleCI Docker jobs to Gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
     docker:
       - image: cimg/ruby:<< parameters.ruby_version >>
         <<: *docker-auth
+    resource_class: medium.gen2
     steps:
       - checkout
       - restore_cache:
@@ -29,6 +30,7 @@ jobs:
     docker:
       - image: cimg/ruby:<< parameters.ruby_version >>
         <<: *docker-auth
+    resource_class: medium.gen2
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
## Summary
- Adds explicit Gen2 resource classes to Docker executors and Docker jobs.
- Preserves existing Docker images, resource sizes, and workflow structure.

## Context
Implements PT-8689. Early outcomes for comparable cw-sherlock, cw-auth, and cw-media migrations are encouraging, but limited in sample size and workload-dependent; this change does not promise a fixed runtime or credit improvement.

## Validation
- Parsed `.circleci/config.yml` with Ruby YAML
- Ran `git diff --check`